### PR TITLE
add support for loongarch

### DIFF
--- a/magic/Magdir/linux
+++ b/magic/Magdir/linux
@@ -166,6 +166,13 @@
 >0x1e3		string	Loading		version 1.3.79 or older
 >0x1e9		string	Loading		from prehistoric times
 
+# Linux kernel boot images (LoongArch)
+0x38		string	LA64        Linux kernel
+>(0x3c.l+4)	leshort	0x6232		LoongArch 32-bit boot executable,
+>(0x3c.l+4)	leshort	0x6264		LoongArch 64-bit boot executable,
+>>526	lelong		>0
+>>>(526.s+0x200) string	>\0		version %s
+
 # System.map files - Nicolas Lichtmaier <nick@debian.org>
 8	search/1	\ A\ _text	Linux kernel symbol map text
 

--- a/magic/Magdir/msdos
+++ b/magic/Magdir/msdos
@@ -136,6 +136,8 @@
 >>(0x3c.l+4)	leshort		0x5032	RISC-V 32-bit
 >>(0x3c.l+4)	leshort		0x5064	RISC-V 64-bit
 >>(0x3c.l+4)	leshort		0x5128	RISC-V 128-bit
+>>(0x3c.l+4)	leshort		0x6232	LoongArch 32-bit
+>>(0x3c.l+4)	leshort		0x6264	LoongArch 64-bit
 >>(0x3c.l+4)	leshort		0x9041	Mitsubishi M32R
 >>(0x3c.l+4)	leshort		0x8664	x86-64
 >>(0x3c.l+4)	leshort		0xaa64	Aarch64

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -177,7 +177,9 @@ enable_sandbox_full(void)
 #endif
 	ALLOW_RULE(fcntl);
  	ALLOW_RULE(fcntl64);
+#ifdef __NR_fstat
 	ALLOW_RULE(fstat);
+#endif
  	ALLOW_RULE(fstat64);
 #ifdef __NR_fstatat64
 	ALLOW_RULE(fstatat64);


### PR DESCRIPTION
增加 LoongArch 架构显示。

## EFI 应用格式

修改前：
```
$ file /boot/efi/EFI/BOOT/BOOTLOONGARCH.EFI
/boot/efi/EFI/BOOT/BOOTLOONGARCH.EFI: PE32+ executable (EFI application) (stripped to external PDB), for MS Windows
```
修改后：
```
$ file -m magic/magic.mgc /boot/efi/EFI/BOOT/BOOTLOONGARCH.EFI 
/boot/efi/EFI/BOOT/BOOTLOONGARCH.EFI: PE32+ executable (EFI application) LoongArch 64-bit (stripped to external PDB), for MS Windows
```

## EFISTUB 内核

修改前：

```
$ file /boot/vmlinuz-linux 
/boot/vmlinuz-linux: MS-DOS executable PE32+ executable (EFI application) (stripped to external PDB), for MS Windows
```
修改后：
```
$ file -m magic/magic.mgc /boot/vmlinuz-linux
/boot/vmlinuz-linux: Linux kernel LoongArch 64-bit boot executable, version 5.15.31-1 (yetist@archlinux) #7 SMP PREEMPT Wed Apr 13 15:32:48 CST 2022
```

